### PR TITLE
feat: add a hello-world w/ OpenShift probes app

### DIFF
--- a/hello-probes/.gitignore
+++ b/hello-probes/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/hello-probes/Dockerfile
+++ b/hello-probes/Dockerfile
@@ -1,0 +1,14 @@
+# podman build -t hello-probes:latest .
+# skopeo copy containers-storage:localhost/hello-probes:latest docker://quay.io/redhattraining/hello-probes:v0.1
+
+FROM rhel8/nodejs-12
+
+MAINTAINER username "username@example.com"
+
+EXPOSE 3000
+
+COPY . /opt/app-root/src
+
+RUN npm install
+
+CMD /bin/bash -c 'npm start'

--- a/hello-probes/app.js
+++ b/hello-probes/app.js
@@ -1,0 +1,89 @@
+const fs = require('fs')
+const start_lock="/tmp/startup.lock"
+const DEFAULT_SLEEP_SECONDS = 60;
+
+var INIT_SLEEP = 0;
+
+// Parse the sleep interval
+try {
+    INIT_SLEEP = Number(process.env.INIT_SLEEP_SECONDS);
+} catch(e) {
+    console.log("Unable to convert sleep parameter; falling back to default value...");
+    INIT_SLEEP = DEFAULT_SLEEP_SECONDS;
+}
+if (isNaN(INIT_SLEEP)) {
+    INIT_SLEEP = DEFAULT_SLEEP_SECONDS;
+}
+console.log("Initial sleep interval: " + Number(INIT_SLEEP));
+
+
+// If a lock file doesn't exist, create a new lock file with the current timestamp.
+if (! fs.existsSync(start_lock)) {
+    console.log("Application starting...");
+    fs.writeFileSync(start_lock, Date.now());
+}
+
+function is_ready() {
+    var startTime = Number(fs.readFileSync(start_lock));
+    var nowTime = Date.now();
+    var difference = nowTime - startTime;
+
+    if (difference < INIT_SLEEP*1000 ) {
+        return false;
+    }
+    return true;
+}
+
+var express = require('express'),
+    app     = express(),
+    bodyParser = require('body-parser'),
+    os = require('os'),
+    hostname = os.hostname();
+
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+
+var port = process.env.PORT || process.env.OPENSHIFT_NODEJS_PORT || 3000,
+    ip   = process.env.IP   || process.env.OPENSHIFT_NODEJS_IP || '0.0.0.0';
+
+var route = express.Router();
+
+app.use('/', route);
+
+// Start defining routes for our app/microservice
+
+// A route that dumps hostname information from pod
+route.get('/', function(req, res) {
+    if (is_ready()) {
+        res.send('Hi! I am running on host -> ' + hostname + '\n');
+    } else {
+        res.statusMessage = "Service Not ready";
+        res.statusCode = 503;
+        res.send('Server Error\n');
+    }
+});
+
+// A route used for the readiness probe in openshift
+route.get('/ready', function(req, res) {
+    if (is_ready()) {
+        res.send('READY\n');
+    } else {
+        res.statusMessage = "Service Not ready";
+        res.statusCode = 503;
+        res.send('NOT READY\n');
+    }
+
+});
+
+
+// A route used for health check in openshift
+route.get('/health', function(req, res) {
+    res.send('OK\n');
+});
+
+
+app.listen(port, ip);
+console.log('nodejs server running on http://%s:%s', ip, port);
+
+module.exports = app;
+

--- a/hello-probes/app.js
+++ b/hello-probes/app.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const start_lock="/tmp/startup.lock"
+const degraded_state_file="/tmp/degraded"
 const DEFAULT_SLEEP_SECONDS = 60;
 
 var INIT_SLEEP = 0;
@@ -78,7 +79,15 @@ route.get('/ready', function(req, res) {
 
 // A route used for health check in openshift
 route.get('/health', function(req, res) {
-    res.send('OK\n');
+    if (fs.existsSync(degraded_state_file)) {
+        res.statusMessage = "Degraded State"
+        res.statusCode = 500
+        res.send('The site is experiencing unusual load.\n' + 
+                 'Please return at a later time.');
+        return
+    } else {
+        res.send('OK\n');
+    }
 });
 
 

--- a/hello-probes/package.json
+++ b/hello-probes/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hello-probes",
+  "main": "app.js",
+  "description": "A simple node.js app with readiness and liveness probes",
+  "dependencies": {
+    "body-parser": "^1.17.1",
+    "express": "^4.*"
+  },
+  "engine": {
+    "node": "*",
+    "npm": "*"
+  },
+  "scripts": {
+    "start": "node app.js"
+  },
+  "author": "Dan Kolepp <dkolepp@redhat.com>",
+  "license": "MIT"
+}


### PR DESCRIPTION
This app is a variant of a "hello-world" app, except that a "/ready" endpoint is defined.  The /ready endpoint returns a "503" HTTP status code, any time the request is within the first 60 seconds of container start-up [or as set by the environment variable INIT_SLEEP_SECONDS].  This allows students to see the effects of a "readiness" probe that does not always return a 200 status code.

Also, the liveness probe immediately responds with a 200 status code.  This could be "altered" later to return a 400 series code based on some event...

