### PR TITLE
exoplanets

### DIFF
--- a/exoplanets/Containerfile
+++ b/exoplanets/Containerfile
@@ -1,0 +1,1 @@
+Dockerfile

--- a/exoplanets/Dockerfile
+++ b/exoplanets/Dockerfile
@@ -4,11 +4,13 @@
 
 # About the 'version' LABEL
 # version="v1.1.0" is based on 'ubi8'
+# version="v1.1.1" is based on 'ubi9'
 
 ################################################################################
 # -- Build stage --
 
-FROM	registry.redhat.io/ubi8/go-toolset:1.18.10-1	AS builder
+# FROM	registry.redhat.io/ubi8/go-toolset:1.18.10-1	AS builder
+FROM	registry.redhat.io/ubi9/go-toolset:1.18.10-4	AS builder
 
 ENV	CGO_ENABLED=1
 
@@ -25,7 +27,8 @@ RUN	go mod init exoplanets && \
 ################################################################################
 # -- App stage --
 
-FROM	registry.redhat.io/ubi8/ubi-minimal:8.7-1107	AS app
+# FROM	registry.redhat.io/ubi8/ubi-minimal:8.7-1107	AS app
+FROM	registry.redhat.io/ubi9/ubi-minimal:9.1.0-1829	AS app
 
 ARG	VERSION
 

--- a/exoplanets/Dockerfile
+++ b/exoplanets/Dockerfile
@@ -1,33 +1,45 @@
+#	Containerfile
+
+# Be sure to match the 'builder' and 'app' image base version (both 'ubi8' or 'ubi9')
+
+# About the 'version' LABEL
+# version="v1.1.0" is based on 'ubi8'
+
+################################################################################
 # -- Build stage --
 
-FROM registry.redhat.io/ubi8/go-toolset:1.12.8 AS builder
+FROM	registry.redhat.io/ubi8/go-toolset:1.18.10-1	AS builder
 
-RUN mkdir -p $HOME/go/src/exoplanets
-WORKDIR $HOME/go/src/exoplanets
-COPY *.go .
+ENV	CGO_ENABLED=1
 
-RUN go get -u \
-      github.com/gorilla/mux \
-      github.com/lib/pq && \
-    go build
+COPY	*.go .
 
+RUN	go mod init exoplanets && \
+	go mod tidy && \
+	go get -u \
+	  github.com/gorilla/mux@latest \
+	  github.com/lib/pq@latest && \
+	go build && \
+	file exoplanets
 
+################################################################################
 # -- App stage --
 
-FROM registry.redhat.io/ubi8-minimal:8.0-213
-LABEL maintainer="jbirchler@redhat.com" \
-      version="v1.0.0"
+FROM	registry.redhat.io/ubi8/ubi-minimal:8.7-1107	AS app
 
-WORKDIR /home
+ARG	VERSION
 
-COPY --from=builder /opt/app-root/src/go/src/exoplanets/exoplanets .
-COPY template.html .
+LABEL	version=${VERSION}
 
-RUN chmod 440 template.html && \
-    chgrp -R 0 . && \
-    chmod -R g=u .
+WORKDIR	/srv
 
-USER 1001
-EXPOSE 8080
+COPY	--from=builder --chmod=0755 /opt/app-root/src/exoplanets .
+COPY	--chmod=0440 template.html .
 
-CMD ["./exoplanets"]
+RUN	chgrp -R 0 . && \
+	chmod -R g=u .
+
+USER	1001
+EXPOSE	8080
+
+CMD	["./exoplanets"]

--- a/exoplanets/Makefile
+++ b/exoplanets/Makefile
@@ -2,8 +2,9 @@ SHELL=/bin/bash
 
 # version v1.0 is the legacy app version
 # version v1.1.0 has "white background" and is based on ubi8 (check Containerfile)
+# version v1.1.1 has "black background" and is based on ubi8 (check Containerfile)
 
-VERSION ?= v1.1.0
+VERSION ?= v1.1.1
 REPO ?= quay.io/redhattraining
 
 LOCAL_ADDRESS = $(shell hostname -I | awk '{print $$2}')
@@ -53,7 +54,8 @@ push:
 	# podman push ${REPO}/exoplanets:latest
 	podman push ${REPO}/exoplanets:${VERSION}
 
-POSTGRES_IMAGE=registry.redhat.io/rhel8/postgresql-13:1-118
+# POSTGRES_IMAGE=registry.redhat.io/rhel8/postgresql-13:1-118
+POSTGRES_IMAGE=registry.redhat.io/rhel9/postgresql-13:1-119
 
 pg:	pg-down pg-up
 

--- a/exoplanets/Makefile
+++ b/exoplanets/Makefile
@@ -1,6 +1,14 @@
-version = v1.0
-repo = quay.io/redhattraining
-local_address = $(shell hostname -i | cut -f 2 -d ' ')
+SHELL=/bin/bash
+
+# version v1.0 is the legacy app version
+# version v1.1.0 has "white background" and is based on ubi8 (check Containerfile)
+
+VERSION ?= v1.1.0
+REPO ?= quay.io/redhattraining
+
+LOCAL_ADDRESS = $(shell hostname -I | awk '{print $$2}')
+
+.PHONY: fmt build run run-without-db tag push pg pg-up pg-down
 
 all: fmt build run
 
@@ -8,40 +16,59 @@ fmt:
 	gofmt -w *.go
 
 build:
-	buildah bud -t exoplanets:latest .
+	buildah build \
+	  --build-arg VERSION=${VERSION} \
+	  -t exoplanets:latest \
+	  $(CURDIR) \
+	;
 
-run:
-	podman run \
-		-p 8080:8080 \
-		-e DB_HOST=$(local_address) \
-		-e DB_PORT=5432 \
-		-e DB_USER=user \
-		-e DB_PASSWORD=password \
-		-e DB_NAME=postgres \
-		exoplanets:latest
+rm:
+	podman rm -f exoplanets
 
-run-without-db:
+run:	rm
 	podman run \
-		-p 8080:8080 \
-		exoplanets:latest
+	  --name exoplanets \
+	  -p 8080:8080 \
+	  -e VERSION=${VERSION} \
+	  -e DB_HOST=${LOCAL_ADDRESS} \
+	  -e DB_PORT=5432 \
+	  -e DB_USER=user \
+	  -e DB_PASSWORD=password \
+	  -e DB_NAME=postgres \
+	  exoplanets:latest \
+	;
+
+run-without-db:	rm
+	podman run \
+	  --name exoplanets \
+	  -p 8080:8080 \
+	  exoplanets:latest \
+	;
 
 tag:
-	buildah tag exoplanets:latest $(repo)/exoplanets:latest
-	buildah tag exoplanets:latest $(repo)/exoplanets:$(version)
+	# buildah tag exoplanets:latest ${REPO}/exoplanets:latest
+	buildah tag exoplanets:latest ${REPO}/exoplanets:${VERSION}
 
 push:
-	podman push $(repo)/exoplanets:latest
-	podman push $(repo)/exoplanets:$(version)
+	# podman push ${REPO}/exoplanets:latest
+	podman push ${REPO}/exoplanets:${VERSION}
+
+POSTGRES_IMAGE=registry.redhat.io/rhel8/postgresql-13:1-118
+
+pg:	pg-down pg-up
 
 pg-up:
 	podman run -d \
-		--name postgres \
-		-p $(local_address):5432:5432 \
-		-e POSTGRES_PASSWORD=password \
-		-e POSTGRES_USER=user \
-		postgres:12-alpine
+	  --name postgres \
+	  -p ${LOCAL_ADDRESS}:5432:5432 \
+	  -e POSTGRESQL_DATABASE=database \
+	  -e POSTGRESQL_USER=user \
+	  -e POSTGRESQL_PASSWORD=password \
+	  -e POSTGRESQL_ADMIN_PASSWORD=postgres \
+	  -e POSTGRESQL_MAX_CONNECTIONS=1000 \
+	  ${POSTGRES_IMAGE} \
+	;
+	podman ps | grep postgres
 
 pg-down:
 	podman rm -f postgres
-
-.PHONY: fmt build run run-without-db tag push pg-up pg-down

--- a/exoplanets/README.md
+++ b/exoplanets/README.md
@@ -11,6 +11,15 @@ datasets and templates proved more complex than the value.
 The exoplanets application does not include the "memory leak" feature that is
 available in the books application.
 
+## Repository and container image tags
+
+- The tag `v1.1.1` points to the _next_ version of the application.
+- The tag `v1.1.0` points to the _current_ version of the application.
+- The tag `v1.0`   points to the _legacy_ version of the application.
+
+These tags correspond to the container images released on quay:
+
+- <https://quay.io/repository/redhattraining/exoplanets?tab=tags>
 
 ## Table Drop Warning
 

--- a/exoplanets/README.md
+++ b/exoplanets/README.md
@@ -47,12 +47,12 @@ easy to refresh the data: `python3 fetch_planets.py > seed.go`
 A Makefile exists to avoid the burden of remembering things.
 
   * `make build`: Builds a container
-  * `make`: Gofmt, build, and run (locally).
+  * `make`: Execute gofmt, build, and run (locally).
 
 
 ## Pushing
 
-First log podman in to quay.io/redhattraining and verify the `version` and `repo` variables in the Makefile.
+First log podman in to quay.io/redhattraining and verify the `VERSION` and `REPO` variables in the Makefile.
 
 Once that's all good: `make tag push`.
 
@@ -63,6 +63,6 @@ There are a few helper tasks in the Makefile that might be of use:
 
   * `make pg-up`: Starts a PostgreSQL container.
   * `make pg-down`: Completely stops (rm -f) PostgreSQL.
-  * `make run`: Runs the app (you'll need to build it first) with DB_HOST to the ip
+  * `make run`: Runs the app (you'll need to build it first) with `DB_HOST` to the ip
   of the postgres container.
-  * `make`: Gofmt, build, and run (locally).
+  * `make`: Execute gofmt, build, and run (locally).

--- a/exoplanets/exoplanets.go
+++ b/exoplanets/exoplanets.go
@@ -28,7 +28,7 @@ func (b *Exoplanets) fetch() {
 
 	log.Printf("Fetching exoplanets")
 
-	rows, err := b.DB.Query(`SELECT name, mass, period, radius FROM exoplanet ORDER BY name ASC`)
+	rows, err := b.DB.Query(`SELECT name, mass, radius, period FROM exoplanet ORDER BY name ASC`)
 	if err != nil {
 		log.Printf("Unable to select exoplanet table:", err)
 		return

--- a/exoplanets/main.go
+++ b/exoplanets/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func version() (v string) {
-	v = "v1.1.0"
+	v = "v1.1.1"
 	return
 }
 

--- a/exoplanets/main.go
+++ b/exoplanets/main.go
@@ -6,11 +6,18 @@ import (
 	"os"
 )
 
+func version() (v string) {
+	v = "v1.1.0"
+	return
+}
+
 func main() {
 	var (
 		db         *sql.DB
 		exoplanets *Exoplanets
 	)
+
+	log.Printf("Starting exoplanets %s\n", version())
 
 	if os.Getenv("DB_HOST") != "" {
 		db = dbConnect(dbInfo{

--- a/exoplanets/server.go
+++ b/exoplanets/server.go
@@ -11,17 +11,35 @@ import (
 
 var homeTemplate *template.Template
 
+type payload struct {
+	AppVersion    string
+	ExoplanetList []Exoplanet
+}
+
 func init() {
 	homeTemplate = template.Must(template.ParseFiles("template.html"))
 }
 
 func listenAndServe(port string, exoplanets *Exoplanets) error {
+
+	var (
+		template_payload payload
+	)
+
 	r := mux.NewRouter()
 
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		exoplanets.fetch()
+
+		template_payload.AppVersion = version()
+		template_payload.ExoplanetList = exoplanets.List
+
 		w.WriteHeader(http.StatusOK)
-		homeTemplate.Execute(w, exoplanets.List)
+		err := homeTemplate.Execute(w, template_payload)
+		if err != nil {
+			log.Fatalf("execution failed: %s", err)
+			panic(err)
+		}
 	})
 
 	r.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/exoplanets/template.html
+++ b/exoplanets/template.html
@@ -8,6 +8,20 @@
       margin: 2em;
       font-size: 100%;
       line-height: 1.5;
+      font-family: Arial, Helvetica, sans-serif;
+      background-color: black;
+      color: white;
+    }
+
+    h1 {
+      color: orange;
+      text-align: center;
+    }
+
+    section {
+      display: inline-grid;
+      width: 22vw;
+      padding: 1em;
     }
 
     table {

--- a/exoplanets/template.html
+++ b/exoplanets/template.html
@@ -1,57 +1,59 @@
 <!doctype html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8">
-  <title>Exoplanets</title>
+  <title>Exoplanets - {{ .AppVersion }}</title>
   <style>
     body {
       margin: 2em;
       font-size: 100%;
       line-height: 1.5;
-      background-color: black;
-      color: white;
-    }
-
-    h1 {
-      color: #fc0;
-    }
-
-    section h1 {
-      color: #09c;
     }
 
     table {
-      border: solid 1px #039;
+      border: solid 1px blue;
       border-collapse: collapse;
       border-spacing: 0;
     }
 
-    table thead {
-      background-color: #039;
+    table caption {
+      color: dodgerblue;
+      font-size: x-large;
     }
 
-    td, th {
-      padding: 0.2em 0.5em;
+    table thead {
+      background-color: darkblue;
+      color: lightgray;
+    }
+
+    td, th
+    {
+      padding: 0.5em;
+      text-align: center;
+      vertical-align: middle;
+      font-weight: bold;
     }
   </style>
 </head>
-
 <body>
-
-  <h1>Exoplanets</h1>
+  <h1>Exoplanets - {{ .AppVersion }}</h1>
 
   <p>
     The planets listed here are a small subset of the known planets found outside of our solar system.
-    Mass and radius are listed in "Jupiter mass" and "Jupiter radius" units. The orbital period is measured in Earth days.
-    The full dataset is available from the <a href="https://github.com/openexoplanetcatalogue/open_exoplanet_catalogue/">Open Exoplanet Catalogue</a>.
   </p>
 
-  {{range .}}
-  <section>
-    <h1>{{.Name}}</h1>
+  <ul>
+    <li>Mass and radius are listed in "<i>Jupiter mass</i>" and "<i>Jupiter radius</i>" units.</li>
+    <li>The orbital period is measured in "<i>Earth days</i>".</li>
+  </ul>
 
+  <p>
+    The full dataset is available from the <a href="https://github.com/openexoplanetcatalogue/open_exoplanet_catalogue/">Open Exoplanet Catalogue</a>.
+  </p>
+  {{ range .ExoplanetList }}
+  <section>
     <table>
+      <caption>{{ .Name }}</caption>
       <thead>
         <tr>
           <th>Mass</th>
@@ -61,15 +63,14 @@
       </thead>
       <tbody>
         <tr>
-          <td>{{.Mass}}</td>
-          <td>{{.Radius}}</td>
-          <td>{{.Period}}</td>
+          <td>{{ .Mass }}</td>
+          <td>{{ .Radius }}</td>
+          <td>{{ .Period }}</td>
         </tr>
       </tbody>
+      <tfoot></tfoot>
     </table>
   </section>
-  {{end}}
-
+  {{ end }}
 </body>
-
 </html>


### PR DESCRIPTION
This PR contains the versions v1.1.0 and v1.1.1 of the exoplanets application.

Please merge this PR with the "merge commit" strategy to keep all the included commits and tags.

- The tag `v1.1.1` points to the _next_ version of the application.
- The tag `v1.1.0` points to the _current_ version of the application.
- The tag `v1.0`   points to the _legacy_ version of the application.

These tags correspond to the container images released on quay:

- https://quay.io/repository/redhattraining/exoplanets?tab=tags